### PR TITLE
Add eureka.standalone.hostname override option

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -5,7 +5,7 @@ eureka:
       instanceId: ${vcap.application.instance_id:${spring.application.name}:${server.port:8080}}
   client:
     serviceUrl:
-      defaultZone: ${vcap.services.service-registry.credentials.uri:http://127.0.0.1:8761}/eureka/
+      defaultZone: ${eureka.standalone.hostname:vcap.services.service-registry.credentials.uri:http://127.0.0.1:8761}/eureka/
 
 foo: bar
 


### PR DESCRIPTION
To run a stand alone eureka server in PCF, this PR provides the option to override using the service-based approach.